### PR TITLE
Updated to vertx 3.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ Vertx Extra
          alt="Maven Artifact">
 </a>
 
-Vertx compatible wrapper around the metrics Java client. 
+Vertx 3.x compatible wrapper around the metrics Java client. 
+
+For Vertx 2.x you must use the 0.4.1 version of this library.  There will be no further development in support of Vertx 2.x and future Vertx 3.x integration 
+will most likely move to Vertx's Metrics SPI.
 
 Instrumenting Your Vertx Application
 ------------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <packaging>jar</packaging>
   <name>Vertx Extra</name>
   <description>Extension to metrics-java-client which adapts the client for use in the Vert.x framework.</description>
-  <version>0.4.2-SNAPSHOT</version>
+  <version>0.5.0-SNAPSHOT</version>
 
   <licenses>
     <license>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <metrics.client.version>0.4.3</metrics.client.version>
     <mockito.version>1.10.19</mockito.version>
     <slf4j.version>1.7.12</slf4j.version>
-    <vertx.version>2.1.6</vertx.version>
+    <vertx.version>3.2.1</vertx.version>
     <vertx.testtools.version>2.0.3-final</vertx.testtools.version>
 
     <!-- Findbugs -->
@@ -149,13 +149,13 @@
     <!-- General -->
     <dependency>
       <groupId>io.vertx</groupId>
-      <artifactId>vertx-platform</artifactId>
+      <artifactId>vertx-core</artifactId>
       <version>${vertx.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
-      <artifactId>vertx-core</artifactId>
+      <artifactId>vertx-codegen</artifactId>
       <version>${vertx.version}</version>
       <scope>provided</scope>
     </dependency>
@@ -204,8 +204,8 @@
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
-      <artifactId>testtools</artifactId>
-      <version>${vertx.testtools.version}</version>
+      <artifactId>vertx-unit</artifactId>
+      <version>${vertx.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/arpnetworking/metrics/vertx/EventBusSink.java
+++ b/src/main/java/com/arpnetworking/metrics/vertx/EventBusSink.java
@@ -26,9 +26,9 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import io.vertx.core.eventbus.EventBus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.vertx.java.core.eventbus.EventBus;
 
 import java.io.IOException;
 

--- a/src/main/java/com/arpnetworking/metrics/vertx/SharedMetrics.java
+++ b/src/main/java/com/arpnetworking/metrics/vertx/SharedMetrics.java
@@ -19,8 +19,7 @@ import com.arpnetworking.metrics.Counter;
 import com.arpnetworking.metrics.Metrics;
 import com.arpnetworking.metrics.Timer;
 import com.arpnetworking.metrics.Unit;
-
-import org.vertx.java.core.shareddata.Shareable;
+import io.vertx.core.shareddata.Shareable;
 
 import java.time.Instant;
 import java.util.Map;

--- a/src/main/java/com/arpnetworking/metrics/vertx/SharedMetricsFactory.java
+++ b/src/main/java/com/arpnetworking/metrics/vertx/SharedMetricsFactory.java
@@ -17,7 +17,7 @@ package com.arpnetworking.metrics.vertx;
 
 import com.arpnetworking.metrics.Metrics;
 import com.arpnetworking.metrics.MetricsFactory;
-import org.vertx.java.core.shareddata.Shareable;
+import io.vertx.core.shareddata.Shareable;
 
 /**
  * An implementation of <code>MetricsFactory</code> that extends Vertx's <code>SharedData</code> which allows use in a

--- a/src/main/java/com/arpnetworking/metrics/vertx/SinkVerticle.java
+++ b/src/main/java/com/arpnetworking/metrics/vertx/SinkVerticle.java
@@ -33,11 +33,11 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Handler;
+import io.vertx.core.eventbus.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.vertx.java.core.Handler;
-import org.vertx.java.core.eventbus.Message;
-import org.vertx.java.platform.Verticle;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -61,7 +61,7 @@ import java.util.Objects;
  *
  * @author Deepika Misra (deepika at groupon dot com)
  */
-public abstract class SinkVerticle extends Verticle {
+public abstract class SinkVerticle extends AbstractVerticle {
 
     /**
      * {@inheritDoc}
@@ -70,9 +70,9 @@ public abstract class SinkVerticle extends Verticle {
     public void start() {
         _sinks = new ArrayList<>(createSinks());
         _handler = initializeHandler();
-        _sinkAddress = container.config().getString("sinkAddress", DEFAULT_SINK_ADDRESS);
+        _sinkAddress = config().getString("sinkAddress", DEFAULT_SINK_ADDRESS);
 
-        vertx.eventBus().registerHandler(_sinkAddress, _handler);
+        vertx.eventBus().localConsumer(_sinkAddress, _handler);
     }
 
     /**

--- a/src/test/java/com/arpnetworking/metrics/vertx/EventBusSinkTest.java
+++ b/src/test/java/com/arpnetworking/metrics/vertx/EventBusSinkTest.java
@@ -25,9 +25,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.collect.ImmutableMap;
+import io.vertx.core.eventbus.EventBus;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.vertx.java.core.eventbus.EventBus;
 
 import java.util.Collections;
 import java.util.List;

--- a/src/test/java/com/arpnetworking/metrics/vertx/SinkHandlerTest.java
+++ b/src/test/java/com/arpnetworking/metrics/vertx/SinkHandlerTest.java
@@ -25,13 +25,13 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.vertx.core.eventbus.Message;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.vertx.java.core.eventbus.Message;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/com/arpnetworking/metrics/vertx/test/TestClientVerticleImpl.java
+++ b/src/test/java/com/arpnetworking/metrics/vertx/test/TestClientVerticleImpl.java
@@ -21,7 +21,7 @@ import com.arpnetworking.metrics.Units;
 import com.arpnetworking.metrics.vertx.EventBusSink;
 import com.arpnetworking.metrics.vertx.SinkVerticle;
 import com.google.common.collect.ImmutableMap;
-import org.vertx.java.platform.Verticle;
+import io.vertx.core.AbstractVerticle;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,7 +33,7 @@ import java.util.Map;
  *
  * @author Deepika Misra (deepika at groupon dot com)
  */
-public class TestClientVerticleImpl extends Verticle {
+public class TestClientVerticleImpl extends AbstractVerticle {
 
     @Override
     public void start() {

--- a/src/test/java/com/arpnetworking/metrics/vertx/test/TestSinkVerticleImpl.java
+++ b/src/test/java/com/arpnetworking/metrics/vertx/test/TestSinkVerticleImpl.java
@@ -20,9 +20,9 @@ import com.arpnetworking.metrics.Sink;
 import com.arpnetworking.metrics.vertx.SinkVerticle;
 import com.google.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.vertx.core.Handler;
+import io.vertx.core.eventbus.Message;
 import org.mockito.Mockito;
-import org.vertx.java.core.Handler;
-import org.vertx.java.core.eventbus.Message;
 
 import java.util.List;
 


### PR DESCRIPTION
Switched to vertx 3.2.1 and made associated changes.

Dropped deprecated and incompatible vertx-testtools and switched to vertx-unit using JUnit integration.